### PR TITLE
Handle SMTP config at startup and clean up imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
 2. **Edit Environment Variables**:  
    Open the `docker-compose.yml` file and set the environment variables according to your setup:
 
-   ```yaml
+    ```yaml
     environment:
-      BASE_URL: https://api.servicesbyv.com # Set this to your actual base URL
+      BASE_URL: https://api.servicesbyv.com  # Set this to your actual base URL
       ROOT_PATH: /email
-      API_KEY: Optional API key to connect to api
-      WORKERS: 1 #uvicorn workers 1 should be enough for personal use
-      UVICORN_CONCURRENCY: 32 #this controls the mac connections. Anything over the API_concurrancy value is put in query pool. Anything over this number is rejected.
+      API_KEY: "Optional API key to connect to api"
+      WORKERS: 1  # uvicorn workers 1 should be enough for personal use
+      UVICORN_CONCURRENCY: 32  # this controls the max connections. Anything over the API_concurrency value is queued and excess rejected.
       ACCOUNT_EMAIL: user1@example.com
       ACCOUNT_PASSWORD: password1
       ACCOUNT_IMAP_SERVER: imap.example.com
@@ -145,7 +145,11 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
       ACCOUNT_SMTP_SERVER: smtp.example.com
       ACCOUNT_SMTP_PORT: 587
       ACCOUNT_REPLY_TO: replyto@example.com
-   ```
+    ```
+
+    The service validates the SMTP settings on startup. Ensure `ACCOUNT_EMAIL`,
+    `ACCOUNT_PASSWORD`, `ACCOUNT_SMTP_SERVER`, and `ACCOUNT_SMTP_PORT` are set
+    or the application will raise a runtime error at launch.
 
 3. **Run the Docker Compose**:  
    Use the following command to start the service:

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -25,14 +25,17 @@ ACCOUNT_PASSWORD = os.getenv("ACCOUNT_PASSWORD")
 ACCOUNT_SMTP_SERVER = os.getenv("ACCOUNT_SMTP_SERVER")
 ACCOUNT_SMTP_PORT = os.getenv("ACCOUNT_SMTP_PORT")
 ACCOUNT_REPLY_TO = os.getenv("ACCOUNT_REPLY_TO")
-FROM_NAME = os.getenv("FROM_NAME", "Your Friendly AI") 
+FROM_NAME = os.getenv("FROM_NAME", "Your Friendly AI")
 SIGNATURE_PATH = "/app/sig/signature.html"
 
-# Validate environment variables
-if not all([ACCOUNT_EMAIL, ACCOUNT_PASSWORD, ACCOUNT_SMTP_SERVER, ACCOUNT_SMTP_PORT]):
-    raise HTTPException(status_code=500, detail="SMTP configuration is incomplete")
 
-ACCOUNT_SMTP_PORT = int(ACCOUNT_SMTP_PORT)
+def validate_smtp_config() -> None:
+    """Validate required SMTP configuration at startup."""
+    global ACCOUNT_SMTP_PORT
+    if not all([ACCOUNT_EMAIL, ACCOUNT_PASSWORD, ACCOUNT_SMTP_SERVER, ACCOUNT_SMTP_PORT]):
+        raise RuntimeError("SMTP configuration is incomplete")
+
+    ACCOUNT_SMTP_PORT = int(ACCOUNT_SMTP_PORT)
 
 ALLOWED_FILE_TYPES = {
     ".zip",
@@ -135,8 +138,9 @@ async def send_email(
                     )
                     part = MIMEBase(main_type, sub_type)
 
-                    with open(file_path, "rb") as file:
-                        part.set_payload(file.read())
+                    async with aiofiles.open(file_path, "rb") as file:
+                        file_data = await file.read()
+                    part.set_payload(file_data)
 
                     encoders.encode_base64(part)
                     part.add_header(

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,8 @@
 import os
 from fastapi import FastAPI
 
-from routes.send_email import send_router
+from .dependencies import validate_smtp_config
+from .routes.send_email import send_router
 
 
 # FastAPI application instance setup
@@ -14,6 +15,12 @@ app = FastAPI(
     root_path_in_servers=False,
     servers=[{"url": f"{os.getenv('BASE_URL', '')}{os.getenv('ROOT_PATH', '/')}", "description": "Base API server"}]
 )
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    validate_smtp_config()
+
 
 # Include routers for feature modules
 app.include_router(send_router)

--- a/app/routes/send_email.py
+++ b/app/routes/send_email.py
@@ -1,7 +1,6 @@
-import os
 from fastapi import APIRouter, Depends, HTTPException
-from models import SendEmailRequest
-from dependencies import send_email, get_api_key
+from ..models import SendEmailRequest
+from ..dependencies import send_email, get_api_key
 
 send_router = APIRouter()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,11 @@ services:
     ports:
       - "8050:8888" # Map port 80 of the container to port 8075 on the host
     environment:
-      BASE_URL: https://api.servicesbyv.com # Set this to your actual base URL
+      BASE_URL: https://api.servicesbyv.com  # Set this to your actual base URL
       ROOT_PATH: /email
-      API_KEY: Optional API key to connect to api
-      WORKERS: 1 #uvicorn workers 1 should be enough for personal use
-      UVICORN_CONCURRENCY: 32 #this controls the mac connections. Anything over the API_concurrancy value is put in query pool. Anything over this number is rejected.
+      API_KEY: "Optional API key to connect to api"  # Optional API key to connect to API
+      WORKERS: 1  # uvicorn workers; 1 should be enough for personal use
+      UVICORN_CONCURRENCY: 32  # Controls max connections. Requests over API_CONCURRENCY are queued or rejected.
       ACCOUNT_EMAIL: user1@example.com
       ACCOUNT_PASSWORD: password1
       ACCOUNT_IMAP_SERVER: imap.example.com


### PR DESCRIPTION
## Summary
- fix relative imports and remove unused import in send_email route
- quote env values and tidy docker-compose comments
- validate SMTP settings on startup and avoid blocking file reads

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1fd02d738832ababd853fffb3162a