### PR TITLE
Use settings object and concurrent download limits

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -18,24 +18,25 @@ from email import encoders
 
 from typing import Optional
 
-
-# Environment variables
-ACCOUNT_EMAIL = os.getenv("ACCOUNT_EMAIL")
-ACCOUNT_PASSWORD = os.getenv("ACCOUNT_PASSWORD")
-ACCOUNT_SMTP_SERVER = os.getenv("ACCOUNT_SMTP_SERVER")
-ACCOUNT_SMTP_PORT = os.getenv("ACCOUNT_SMTP_PORT")
-ACCOUNT_REPLY_TO = os.getenv("ACCOUNT_REPLY_TO")
-FROM_NAME = os.getenv("FROM_NAME", "Your Friendly AI")
-SIGNATURE_PATH = "/app/sig/signature.html"
+from pydantic import EmailStr, Field
+from pydantic_settings import BaseSettings
 
 
-def validate_smtp_config() -> None:
-    """Validate required SMTP configuration at startup."""
-    global ACCOUNT_SMTP_PORT
-    if not all([ACCOUNT_EMAIL, ACCOUNT_PASSWORD, ACCOUNT_SMTP_SERVER, ACCOUNT_SMTP_PORT]):
-        raise RuntimeError("SMTP configuration is incomplete")
+class Config(BaseSettings):
+    """Application configuration loaded from environment variables."""
 
-    ACCOUNT_SMTP_PORT = int(ACCOUNT_SMTP_PORT)
+    account_email: EmailStr = Field(env="ACCOUNT_EMAIL")
+    account_password: str = Field(env="ACCOUNT_PASSWORD")
+    account_smtp_server: str = Field(env="ACCOUNT_SMTP_SERVER")
+    account_smtp_port: int = Field(env="ACCOUNT_SMTP_PORT")
+    account_reply_to: EmailStr = Field(env="ACCOUNT_REPLY_TO")
+    from_name: str = Field(default="Your Friendly AI", env="FROM_NAME")
+    attachment_concurrency: int = Field(default=5, env="ATTACHMENT_CONCURRENCY")
+    start_tls: bool = Field(default=True, env="START_TLS")
+
+
+settings: Config | None = None
+signature_text: str = ""
 
 ALLOWED_FILE_TYPES = {
     ".zip",
@@ -78,43 +79,38 @@ async def fetch_file(session, url, temp_dir) -> str:
         return file_path
 
 async def send_email(
-    to_address: str,
+    to_addresses: list[EmailStr],
     subject: str,
     body: str,
     file_url: Optional[str] = None,
 ) -> None:
+    if settings is None:
+        raise RuntimeError("Settings have not been initialized")
+
     msg = MIMEMultipart()
-    # Convert to_address string into a list of email addresses
-    to_addresses = [address.strip() for address in to_address.split(",")]
-    msg["From"] = f"{FROM_NAME} <{ACCOUNT_EMAIL}>"
+    msg["From"] = f"{settings.from_name} <{settings.account_email}>"
     msg["To"] = ", ".join(to_addresses)
     msg["Subject"] = subject
-    msg["Reply-To"] = ACCOUNT_REPLY_TO
+    msg["Reply-To"] = settings.account_reply_to
 
-    # Add the email body and optional signature
-    signature = ""
-    if os.path.exists(SIGNATURE_PATH) and os.access(SIGNATURE_PATH, os.R_OK):
-        async with aiofiles.open(SIGNATURE_PATH, "r") as file:
-            signature = await file.read()
-    else:
-        print("Signature file not found or is not readable. Proceeding without it.")
-
-    msg.attach(MIMEText(body + signature, "html"))
+    msg.attach(MIMEText(body + signature_text, "html"))
 
     # Handle file attachments
     if file_url:
-        # Convert the file_url string into a list of URLs
         file_urls = [url.strip() for url in file_url.split(",")]
 
         total_size = 0
         temp_dir = tempfile.mkdtemp()
+        semaphore = asyncio.Semaphore(settings.attachment_concurrency)
+        connector = aiohttp.TCPConnector(limit=settings.attachment_concurrency)
+
+        async def sem_fetch(url: str) -> str:
+            async with semaphore:
+                return await fetch_file(session, url, temp_dir)
 
         try:
-            async with aiohttp.ClientSession() as session:
-                # Download all files concurrently
-                file_paths = await asyncio.gather(
-                    *(fetch_file(session, url, temp_dir) for url in file_urls)
-                )
+            async with aiohttp.ClientSession(connector=connector) as session:
+                file_paths = await asyncio.gather(*(sem_fetch(url) for url in file_urls))
 
                 for file_path in file_paths:
                     file_size = os.path.getsize(file_path)
@@ -160,11 +156,11 @@ async def send_email(
     try:
         await aiosmtplib.send(
             msg,
-            hostname=ACCOUNT_SMTP_SERVER,
-            port=ACCOUNT_SMTP_PORT,
-            username=ACCOUNT_EMAIL,
-            password=ACCOUNT_PASSWORD,
-            start_tls=True,
+            hostname=settings.account_smtp_server,
+            port=settings.account_smtp_port,
+            username=settings.account_email,
+            password=settings.account_password,
+            start_tls=settings.start_tls,
         )
     except aiosmtplib.errors.SMTPException as e:
         print(f"SMTPException: {str(e)}")

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
 # main,py
 import os
+import aiofiles
 from fastapi import FastAPI
 
-from .dependencies import validate_smtp_config
+from . import dependencies
 from .routes.send_email import send_router
 
 
@@ -19,7 +20,12 @@ app = FastAPI(
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    validate_smtp_config()
+    dependencies.settings = dependencies.Config()
+    try:
+        async with aiofiles.open("config/signature.txt", "r") as file:
+            dependencies.signature_text = await file.read()
+    except FileNotFoundError:
+        dependencies.signature_text = ""
 
 
 # Include routers for feature modules

--- a/app/models.py
+++ b/app/models.py
@@ -1,11 +1,11 @@
 # models.py
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, EmailStr
 from typing import Optional
 
 class SendEmailRequest(BaseModel):
-    to_address: str = Field(
+    to_addresses: list[EmailStr] = Field(
         ...,
-        description="The recipient's email address or comma-separated list of email addresses.",
+        description="List of recipient email addresses.",
     )
     subject: str = Field(..., description="The subject of the email.", max_length=255)
     body: str = Field(..., description="The body content of the email.")

--- a/app/routes/send_email.py
+++ b/app/routes/send_email.py
@@ -4,17 +4,15 @@ from ..dependencies import send_email, get_api_key
 
 send_router = APIRouter()
 
-@send_router.post("/", operation_id="send_email")
-async def send_email_endpoint(
-    request: SendEmailRequest, api_key: str = Depends(get_api_key)
-):
-    to_address = request.to_address
+
+@send_router.post("/", operation_id="send_email", dependencies=[Depends(get_api_key)])
+async def send_email_endpoint(request: SendEmailRequest):
     subject = request.subject
     body = request.body
     file_url = request.file_url
 
     try:
-        await send_email(to_address, subject, body, file_url)
+        await send_email(request.to_addresses, subject, body, file_url)
         return {"message": "Email sent successfully"}
     except HTTPException as e:
         print(f"HTTPException: {e.detail}")

--- a/config/signature.txt
+++ b/config/signature.txt
@@ -1,0 +1,1 @@
+<br><br>Best regards,<br>Your Friendly AI

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiosmtplib==3.0.2
 aiohttp==3.11.7
 aiofiles==24.1.0
 python-dotenv==1.0.1
+pydantic-settings==2.6.1


### PR DESCRIPTION
## Summary
- cache email signature and load config on startup
- validate recipient list with EmailStr and drop inline API key param
- limit concurrent attachment downloads and move SMTP config to BaseSettings

## Testing
- `python -m py_compile app/dependencies.py app/main.py app/models.py app/routes/send_email.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c20534e140832aba49b765567b509d