### PR TITLE
build: optimize Docker image and ignore non-runtime files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,16 @@
 .github
 .gitea
 .venv
+tests/
+.env
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.cache
+*.log
+docker-compose.yml
+.gitattributes
+.gitignore
+*.md
+*.png
+config/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Header decoding concatenates multi-part encodings.
 - Attachment downloads restricted to HTTP/HTTPS schemes.
 - Email summary dates stored as `datetime` and serialized in ISO format.
+### Changed
+- Dockerfile uses BuildKit cache for pip installations and exec-form `CMD`.
+- `.dockerignore` expanded to exclude tests, caches, and other non-runtime files.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ FROM python:3.10-slim as builder
 # Set the working directory
 WORKDIR /app
 
-# Copy the requirements file and cache
-COPY /cache /app/cache
+# Copy the requirements file
 COPY requirements.txt /app
 
 # Install Python dependencies in a virtual environment
-RUN python -m venv /app/venv && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m venv /app/venv && \
     . /app/venv/bin/activate && \
-    pip install --no-index --find-links /app/cache -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -rf /root/.cache/pip
 
 # Final stage
 FROM python:3.10-slim
@@ -25,7 +26,7 @@ COPY --from=builder /app/venv /app/venv
 # Copy the rest of the application
 COPY ./app /app
 
-# Expose port 8040 to the outside world
+# Expose port 8888 to the outside world
 EXPOSE 8888
 
 # Define environment variables
@@ -34,4 +35,4 @@ ENV UVICORN_CONCURRENCY=32
 ENV PATH="/app/venv/bin:$PATH"
 
 # Set the command to run your FastAPI application with Uvicorn and environment variables
-CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port 8888 --workers $WORKERS --limit-concurrency $UVICORN_CONCURRENCY --timeout-keep-alive 32"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8888", "--workers", "$WORKERS", "--limit-concurrency", "$UVICORN_CONCURRENCY", "--timeout-keep-alive", "32"]


### PR DESCRIPTION
## Summary
- add pip BuildKit cache and remove leftover caches
- switch to exec-form uvicorn command
- ignore tests, caches and local files in docker context

## Testing
- `flake8 --max-line-length=120 app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c22fac7cdc832abf4eae6d02f614d1