### PR TITLE
Add OpenAPI metadata and consistent message responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Header decoding concatenates multi-part encodings.
 - Attachment downloads restricted to HTTP/HTTPS schemes.
 - Email summary dates stored as `datetime` and serialized in ISO format.
+- Contact, license, and terms metadata added to the FastAPI application along with Send/Read tags.
+- Consistent `MessageResponse` model used across message endpoints and documented error responses.
+- Named API key bearer security scheme exposed in the OpenAPI schema.

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -24,6 +24,13 @@ from pydantic import EmailStr, Field
 from pydantic_settings import BaseSettings
 
 
+api_key_scheme = HTTPBearer(
+    auto_error=False,
+    scheme_name="APIKey",
+    description="Supply the API key as a Bearer token in the Authorization header.",
+)
+
+
 class Config(BaseSettings):
     """Application configuration loaded from environment variables."""
 
@@ -184,7 +191,7 @@ async def send_email(
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
 async def get_api_key(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False)),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(api_key_scheme),
 ) -> Optional[str]:
     # Retrieve the API key from the environment
     expected_key = os.getenv("API_KEY")

--- a/app/main.py
+++ b/app/main.py
@@ -8,14 +8,29 @@ from .routes.send_email import send_router
 from .routes.read_email import read_router
 
 
+openapi_tags = [{"name": "Send"}, {"name": "Read"}]
+
+
 # FastAPI application instance setup
 app = FastAPI(
     title="Email Management API",
     version="0.1.0",
     description="A FastAPI to send emails",
+    contact={"name": "API Support", "email": "support@example.com"},
+    license_info={
+        "name": "MIT License",
+        "url": "https://opensource.org/licenses/MIT",
+    },
+    terms_of_service="https://example.com/terms/",
+    openapi_tags=openapi_tags,
     root_path=os.getenv('ROOT_PATH', '/'),
     root_path_in_servers=False,
-    servers=[{"url": f"{os.getenv('BASE_URL', '')}{os.getenv('ROOT_PATH', '/')}", "description": "Base API server"}]
+    servers=[
+        {
+            "url": f"{os.getenv('BASE_URL', '')}{os.getenv('ROOT_PATH', '/')}",
+            "description": "Base API server",
+        }
+    ]
 )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -27,3 +27,7 @@ class EmailSummary(BaseModel):
     class Config:
         allow_population_by_field_name = True
         json_encoders = {datetime: lambda v: v.isoformat()}
+
+
+class MessageResponse(BaseModel):
+    message: str

--- a/tests/test_read_email.py
+++ b/tests/test_read_email.py
@@ -59,6 +59,7 @@ def test_move_email(monkeypatch):
     response = client.post("/emails/1/move?folder=Archive&source_folder=Old")
     assert response.status_code == 200
     assert called == {"uid": "1", "folder": "Archive", "source": "Old"}
+    assert response.json() == {"message": "Email moved"}
 
 
 def test_delete_email(monkeypatch):
@@ -72,6 +73,7 @@ def test_delete_email(monkeypatch):
     response = client.delete("/emails/2?folder=INBOX")
     assert response.status_code == 200
     assert called == {"uid": "2", "folder": "INBOX"}
+    assert response.json() == {"message": "Email deleted"}
 
 
 def test_forward_email(monkeypatch):
@@ -97,6 +99,7 @@ def test_forward_email(monkeypatch):
     assert response.status_code == 200
     assert sent["headers"]["In-Reply-To"] == "<1@example.com>"
     assert sent["headers"]["References"] == "<1@example.com>"
+    assert response.json() == {"message": "Email forwarded"}
 
 
 def test_reply_email(monkeypatch):
@@ -122,6 +125,7 @@ def test_reply_email(monkeypatch):
     assert response.status_code == 200
     assert sent["subject"].startswith("Re: ")
     assert sent["headers"]["In-Reply-To"] == "<2@example.com>"
+    assert response.json() == {"message": "Email sent"}
 
 
 def test_create_draft(monkeypatch):
@@ -137,3 +141,4 @@ def test_create_draft(monkeypatch):
     )
     assert response.status_code == 200
     assert called["folder"] == "Drafts"
+    assert response.json() == {"message": "Draft stored"}

--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -1,0 +1,32 @@
+# flake8: noqa
+import os
+import sys
+from fastapi.testclient import TestClient
+
+os.environ["ACCOUNT_EMAIL"] = "user@example.com"
+os.environ["ACCOUNT_PASSWORD"] = "password"
+os.environ["ACCOUNT_SMTP_SERVER"] = "smtp.example.com"
+os.environ["ACCOUNT_SMTP_PORT"] = "587"
+os.environ["ACCOUNT_IMAP_SERVER"] = "imap.example.com"
+os.environ["ACCOUNT_IMAP_PORT"] = "993"
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.main import app  # noqa: E402
+from app import dependencies
+
+dependencies.settings = dependencies.Config()
+client = TestClient(app)
+
+
+def test_send_email(monkeypatch):
+    async def mock_send_email(to_addresses, subject, body, file_url, headers=None):
+        return None
+
+    monkeypatch.setattr("app.routes.send_email.send_email", mock_send_email)
+    response = client.post(
+        "/",
+        json={"to_addresses": ["a@b.com"], "subject": "Sub", "body": "Body", "file_url": None},
+    )
+    assert response.status_code == 201
+    assert response.json() == {"message": "Email sent successfully"}


### PR DESCRIPTION
## Summary
- enrich FastAPI app with contact, license, terms, and tagged routes
- standardize message payloads via MessageResponse and detailed route metadata
- expose named API key bearer scheme

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c240d56ee0832a9d2e0df0880fbccd