### PR TITLE
test: expand dependency coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Contact, license, and terms metadata added to the FastAPI application along with Send/Read tags.
 - Consistent `MessageResponse` model used across message endpoints and documented error responses.
 - Named API key bearer security scheme exposed in the OpenAPI schema.
+- Tests for API key validation and email sending error handling.

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -4,6 +4,7 @@ import sys
 import asyncio
 import pytest
 from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
 
 os.environ["ACCOUNT_EMAIL"] = "user@example.com"
 os.environ["ACCOUNT_PASSWORD"] = "password"
@@ -24,3 +25,45 @@ class DummySession:
 def test_fetch_file_invalid_scheme(tmp_path):
     with pytest.raises(HTTPException):
         asyncio.run(dependencies.fetch_file(DummySession(), "ftp://example.com/file.txt", tmp_path))
+
+
+def test_send_email_without_settings():
+    original = dependencies.settings
+    dependencies.settings = None
+    with pytest.raises(RuntimeError):
+        asyncio.run(
+            dependencies.send_email(
+                ["a@example.com"],
+                "Subject",
+                "Body",
+            )
+        )
+    dependencies.settings = original
+
+
+def test_get_api_key_without_env(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+    assert (
+        asyncio.run(dependencies.get_api_key(credentials=creds))
+        == "token"
+    )
+    assert asyncio.run(dependencies.get_api_key(credentials=None)) is None
+
+
+def test_get_api_key_with_env_valid(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="secret")
+    assert (
+        asyncio.run(dependencies.get_api_key(credentials=creds))
+        == "secret"
+    )
+
+
+def test_get_api_key_with_env_invalid(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong")
+    with pytest.raises(HTTPException):
+        asyncio.run(dependencies.get_api_key(credentials=creds))
+    with pytest.raises(HTTPException):
+        asyncio.run(dependencies.get_api_key(credentials=None))


### PR DESCRIPTION
## Summary
- expand dependency tests for email sending and API key validation

## Testing
- `python -m pytest`
- `python -m flake8`


------
https://chatgpt.com/codex/tasks/task_e_68c242654d9c832a8990a7477a15a19e