### PR TITLE
refactor: dynamic settings and reply-to configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,8 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Named API key bearer security scheme exposed in the OpenAPI schema.
 - Tests for API key validation and email sending error handling.
 - Extensive tests for dependencies, IMAP client, routes, models, and startup logic.
+- `account_reply_to` configuration option for customizing the Reply-To header.
+
+### Changed
+- Routes and IMAP client now reference settings dynamically via `dependencies.settings`.
+- Explicit operation IDs defined for read email endpoints.

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -43,11 +43,11 @@ class Config(BaseSettings):
     from_name: str = Field(default="", env="FROM_NAME")
     attachment_concurrency: int = Field(default=3, env="ATTACHMENT_CONCURRENCY")
     start_tls: bool = Field(default=True, env="START_TLS")
+    account_reply_to: EmailStr | None = Field(default=None, env="ACCOUNT_REPLY_TO")
 
 
 settings: Config | None = None
 signature_text: str = ""
-ACCOUNT_REPLY_TO = os.getenv("ACCOUNT_REPLY_TO")
 
 ALLOWED_FILE_TYPES = {
     ".zip",
@@ -107,8 +107,8 @@ async def send_email(
     msg["From"] = f"{settings.from_name} <{settings.account_email}>"
     msg["To"] = ", ".join(to_addresses)
     msg["Subject"] = subject
-    if ACCOUNT_REPLY_TO is not None:
-        msg["Reply-To"] = ACCOUNT_REPLY_TO
+    if settings.account_reply_to is not None:
+        msg["Reply-To"] = settings.account_reply_to
 
     msg.attach(MIMEText(body + signature_text, "html"))
 

--- a/app/services/imap_client.py
+++ b/app/services/imap_client.py
@@ -8,7 +8,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import parsedate_to_datetime
 
-from ..dependencies import settings
+from .. import dependencies
 from ..models import EmailSummary
 
 
@@ -48,10 +48,13 @@ async def list_mailboxes() -> list[str]:
     """Return a list of mailbox names."""
 
     def inner() -> list[str]:
-        if settings is None:
+        if dependencies.settings is None:
             raise RuntimeError("Settings have not been initialized")
-        with imaplib.IMAP4_SSL(settings.account_imap_server, settings.account_imap_port) as imap:
-            imap.login(settings.account_email, settings.account_password)
+        with imaplib.IMAP4_SSL(
+            dependencies.settings.account_imap_server,
+            dependencies.settings.account_imap_port,
+        ) as imap:
+            imap.login(dependencies.settings.account_email, dependencies.settings.account_password)
             typ, data = imap.list()
             if typ != "OK" or data is None:
                 return []
@@ -73,10 +76,13 @@ async def fetch_messages(folder: str = "INBOX", limit: int = 10, unread_only: bo
     """Fetch message headers from a folder and return summaries."""
 
     def inner() -> list[EmailSummary]:
-        if settings is None:
+        if dependencies.settings is None:
             raise RuntimeError("Settings have not been initialized")
-        with imaplib.IMAP4_SSL(settings.account_imap_server, settings.account_imap_port) as imap:
-            imap.login(settings.account_email, settings.account_password)
+        with imaplib.IMAP4_SSL(
+            dependencies.settings.account_imap_server,
+            dependencies.settings.account_imap_port,
+        ) as imap:
+            imap.login(dependencies.settings.account_email, dependencies.settings.account_password)
             imap.select(folder)
             criteria = "UNSEEN" if unread_only else "ALL"
             typ, data = imap.search(None, criteria)
@@ -109,10 +115,13 @@ async def move_message(uid: str, folder: str, source_folder: str = "INBOX") -> N
     """Move a message to another folder."""
 
     def inner() -> None:
-        if settings is None:
+        if dependencies.settings is None:
             raise RuntimeError("Settings have not been initialized")
-        with imaplib.IMAP4_SSL(settings.account_imap_server, settings.account_imap_port) as imap:
-            imap.login(settings.account_email, settings.account_password)
+        with imaplib.IMAP4_SSL(
+            dependencies.settings.account_imap_server,
+            dependencies.settings.account_imap_port,
+        ) as imap:
+            imap.login(dependencies.settings.account_email, dependencies.settings.account_password)
             imap.select(source_folder)
             imap.uid("COPY", uid, folder)
             imap.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
@@ -125,10 +134,13 @@ async def delete_message(uid: str, folder: str = "INBOX") -> None:
     """Delete a message from a folder."""
 
     def inner() -> None:
-        if settings is None:
+        if dependencies.settings is None:
             raise RuntimeError("Settings have not been initialized")
-        with imaplib.IMAP4_SSL(settings.account_imap_server, settings.account_imap_port) as imap:
-            imap.login(settings.account_email, settings.account_password)
+        with imaplib.IMAP4_SSL(
+            dependencies.settings.account_imap_server,
+            dependencies.settings.account_imap_port,
+        ) as imap:
+            imap.login(dependencies.settings.account_email, dependencies.settings.account_password)
             imap.select(folder)
             imap.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
             imap.expunge()
@@ -140,10 +152,13 @@ async def append_message(folder: str, msg: MIMEMultipart) -> None:
     """Append a raw message to the specified folder."""
 
     def inner() -> None:
-        if settings is None:
+        if dependencies.settings is None:
             raise RuntimeError("Settings have not been initialized")
-        with imaplib.IMAP4_SSL(settings.account_imap_server, settings.account_imap_port) as imap:
-            imap.login(settings.account_email, settings.account_password)
+        with imaplib.IMAP4_SSL(
+            dependencies.settings.account_imap_server,
+            dependencies.settings.account_imap_port,
+        ) as imap:
+            imap.login(dependencies.settings.account_email, dependencies.settings.account_password)
             imap.append(folder, "", imaplib.Time2Internaldate(time.time()), msg.as_bytes())
 
     await asyncio.to_thread(inner)
@@ -153,10 +168,16 @@ async def fetch_message(uid: str, folder: str = "INBOX") -> email.message.Messag
     """Fetch a full message by UID."""
 
     def inner() -> email.message.Message:
-        if settings is None:
+        if dependencies.settings is None:
             raise RuntimeError("Settings have not been initialized")
-        with imaplib.IMAP4_SSL(settings.account_imap_server, settings.account_imap_port) as imap:
-            imap.login(settings.account_email, settings.account_password)
+        with imaplib.IMAP4_SSL(
+            dependencies.settings.account_imap_server,
+            dependencies.settings.account_imap_port,
+        ) as imap:
+            imap.login(
+                dependencies.settings.account_email,
+                dependencies.settings.account_password,
+            )
             imap.select(folder)
             typ, msg_data = imap.uid("fetch", uid, "(RFC822)")
             if typ != "OK" or msg_data is None or not msg_data[0]:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -93,7 +93,7 @@ def test_send_email_with_attachment(monkeypatch):
         sent["msg"] = msg
 
     monkeypatch.setattr(aiosmtplib, "send", mock_send)
-    dependencies.ACCOUNT_REPLY_TO = "reply@example.com"
+    dependencies.settings.account_reply_to = "reply@example.com"
     asyncio.run(dependencies.send_email(["a@b.com"], "Sub", "Body", "http://f1.txt"))
     assert "Reply-To" in sent["msg"]
 
@@ -128,7 +128,7 @@ def test_send_email_single_file_oversize(monkeypatch):
 
 
 def test_send_email_missing_reply_to(monkeypatch):
-    dependencies.ACCOUNT_REPLY_TO = None
+    dependencies.settings.account_reply_to = None
     sent = {}
 
     async def mock_send(msg, **kwargs):

--- a/tests/test_read_email.py
+++ b/tests/test_read_email.py
@@ -20,7 +20,6 @@ from datetime import datetime
 from app.routes import read_email
 
 dependencies.settings = dependencies.Config()
-read_email.settings = dependencies.settings
 client = TestClient(app)
 
 


### PR DESCRIPTION
## Summary
- use dynamic `dependencies.settings` in routes and IMAP client
- add explicit operation IDs for email routes
- move `ACCOUNT_REPLY_TO` into Config and update tests

## Testing
- `flake8 .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c28d361c1c832aae36e96e54a81c06