### PR TITLE
feat: support multiple attachment URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 ### Changed
 - Routes and IMAP client now reference settings dynamically via `dependencies.settings`.
 - Explicit operation IDs defined for read email endpoints.
+- `send_email` accepts a list of attachment URLs via `file_urls` instead of a comma-separated string.

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -97,7 +97,7 @@ async def send_email(
     to_addresses: list[EmailStr],
     subject: str,
     body: str,
-    file_url: Optional[str] = None,
+    file_urls: Optional[list[str]] = None,
     headers: Optional[dict[str, str]] = None,
 ) -> None:
     if settings is None:
@@ -117,9 +117,7 @@ async def send_email(
             msg[key] = value
 
     # Handle file attachments
-    if file_url:
-        file_urls = [url.strip() for url in file_url.split(",")]
-
+    if file_urls:
         total_size = 0
         temp_dir = tempfile.mkdtemp()
         semaphore = asyncio.Semaphore(settings.attachment_concurrency)

--- a/app/routes/read_email.py
+++ b/app/routes/read_email.py
@@ -106,7 +106,10 @@ async def forward_email(
         if msg_id:
             headers["In-Reply-To"] = msg_id
             headers["References"] = msg_id
-        await send_email(request.to_addresses, subject, body, request.file_url, headers=headers)
+        file_urls = [str(url) for url in request.file_url] if request.file_url else None
+        await send_email(
+            request.to_addresses, subject, body, file_urls=file_urls, headers=headers
+        )
         return MessageResponse(message="Email forwarded")
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
@@ -141,7 +144,10 @@ async def reply_email(
         if msg_id:
             headers["In-Reply-To"] = msg_id
             headers["References"] = msg_id
-        await send_email(request.to_addresses, subject, body, request.file_url, headers=headers)
+        file_urls = [str(url) for url in request.file_url] if request.file_url else None
+        await send_email(
+            request.to_addresses, subject, body, file_urls=file_urls, headers=headers
+        )
         return MessageResponse(message="Email sent")
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/app/routes/send_email.py
+++ b/app/routes/send_email.py
@@ -21,10 +21,14 @@ send_router = APIRouter(tags=["Send"])
 async def send_email_endpoint(request: SendEmailRequest) -> MessageResponse:
     subject = request.subject
     body = request.body
-    file_url = request.file_url
+    file_urls = (
+        [str(url) for url in request.file_url] if request.file_url else None
+    )
 
     try:
-        await send_email(request.to_addresses, subject, body, file_url)
+        await send_email(
+            request.to_addresses, subject, body, file_urls=file_urls
+        )
         return MessageResponse(message="Email sent successfully")
     except HTTPException as e:
         print(f"HTTPException: {e.detail}")

--- a/tests/test_read_email.py
+++ b/tests/test_read_email.py
@@ -87,8 +87,8 @@ def test_forward_email(monkeypatch):
 
     sent = {}
 
-    async def mock_send(to, subject, body, file_url, headers):
-        sent.update({"to": to, "subject": subject, "body": body, "headers": headers})
+    async def mock_send(to, subject, body, file_urls, headers):
+        sent.update({"to": to, "subject": subject, "body": body, "headers": headers, "files": file_urls})
 
     monkeypatch.setattr(imap_client, "fetch_message", mock_fetch)
     monkeypatch.setattr(imap_client, "extract_body", lambda msg: "body")
@@ -118,8 +118,8 @@ def test_reply_email(monkeypatch):
 
     sent = {}
 
-    async def mock_send(to, subject, body, file_url, headers):
-        sent.update({"to": to, "subject": subject, "body": body, "headers": headers})
+    async def mock_send(to, subject, body, file_urls, headers):
+        sent.update({"to": to, "subject": subject, "body": body, "headers": headers, "files": file_urls})
 
     monkeypatch.setattr(imap_client, "fetch_message", mock_fetch)
     monkeypatch.setattr(imap_client, "extract_body", lambda msg: "orig body")

--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -21,16 +21,26 @@ client = TestClient(app)
 
 
 def test_send_email(monkeypatch):
-    async def mock_send_email(to_addresses, subject, body, file_url, headers=None):
+    captured = {}
+
+    async def mock_send_email(to_addresses, subject, body, file_urls, headers=None):
+        captured["file_urls"] = file_urls
         return None
 
     monkeypatch.setattr("app.routes.send_email.send_email", mock_send_email)
+    urls = ["http://f1.txt/", "http://f2.txt/"]
     response = client.post(
         "/",
-        json={"to_addresses": ["a@b.com"], "subject": "Sub", "body": "Body", "file_url": None},
+        json={
+            "to_addresses": ["a@b.com"],
+            "subject": "Sub",
+            "body": "Body",
+            "file_url": urls,
+        },
     )
     assert response.status_code == 201
     assert response.json() == {"message": "Email sent successfully"}
+    assert captured["file_urls"] == urls
 
 def test_send_email_http_error(monkeypatch):
     async def mock_send(*a, **k):


### PR DESCRIPTION
## Summary
- allow `send_email` to receive a list of attachment URLs
- update routes to pass `file_urls` and convert `HttpUrl` values
- test sending emails with multiple attachments

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c299a00914832aa87f7fd025fae6cb