### PR TITLE
refactor: remove explicit logging configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Send email endpoint now returns HTTP 200 on success.
 - Forwarding emails respect the provided request body.
 - `limit` query parameters on email listing routes must be positive.
-- Console prints replaced with structured logging and logging configured at startup.
+- Console prints replaced with structured logging; logging configuration is now left to the host environment.
 - Startup now validates required environment variables before initializing settings.
 - Shared IMAP operations consolidated into reusable helpers.
 

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app):
-    logging.basicConfig(level=logging.INFO)
     required = [
         "ACCOUNT_EMAIL",
         "ACCOUNT_PASSWORD",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 import os
 import sys
 from pathlib import Path
+import logging
 from fastapi.testclient import TestClient
 import pytest
 
@@ -41,6 +42,21 @@ def test_startup_without_signature(tmp_path):
     assert dependencies.signature_text == ""
     if temp.exists():
         temp.rename(sig_file)
+
+
+def test_startup_does_not_configure_logging(monkeypatch):
+    original_level = logging.getLogger().level
+    called = False
+
+    def fake_basicConfig(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basicConfig)
+    with TestClient(app):
+        pass
+    assert not called
+    assert logging.getLogger().level == original_level
 
 
 def test_startup_missing_env(monkeypatch):


### PR DESCRIPTION
## Summary
- avoid configuring logging in lifespan
- ensure startup leaves logging unchanged
- document logging change in changelog

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf7beb18832a90339e11aec6d32c