### PR TITLE
Refactor auth and email handlers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,16 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Explicit operation IDs defined for read email endpoints.
 - `send_email` accepts a list of attachment URLs via `file_urls` instead of a comma-separated string.
 - API routes now use `Security(get_api_key)` for API-key protection and include descriptive OpenAPI tags.
-- Send email endpoint now returns HTTP 200 on success.
+- Send email endpoint now returns HTTP 201 on success.
 - Forwarding emails respect the provided request body.
 - `limit` query parameters on email listing routes must be positive.
 - Console prints replaced with structured logging and logging configured at startup.
 - Startup now validates required environment variables before initializing settings.
 - Shared IMAP operations consolidated into reusable helpers.
+- API key retrieval and HTTP exception handling are now synchronous.
+- Forward and reply endpoints accept an optional folder parameter.
+- Tests use `pytest.mark.asyncio` instead of `asyncio.run`.
+- Removed blanket `flake8` ignores in favor of targeted suppressions.
 
 ### Removed
 - Deprecated `app/services/imap_client.py` in favor of a dedicated IMAP router.

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
-# flake8: noqa
 import os
 import logging
 import aiofiles
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
@@ -17,11 +17,6 @@ tags_metadata = [
     {"name": "Read", "description": "Endpoints for reading emails"},
     {"name": "IMAP", "description": "Low-level IMAP operations"},
 ]
-
-
-# FastAPI application instance setup
-from contextlib import asynccontextmanager
-
 logger = logging.getLogger(__name__)
 
 
@@ -57,13 +52,14 @@ async def lifespan(app):
         dependencies.signature_text = ""
     yield
 
+
 app = FastAPI(
     title="Email Management API",
     version="0.1.0",
     description="A FastAPI to send emails",
     openapi_version="3.1.0",
     openapi_tags=tags_metadata,
-    root_path=os.getenv('ROOT_PATH', '/'),
+    root_path=os.getenv("ROOT_PATH", "/"),
     root_path_in_servers=False,
     servers=[
         {
@@ -71,15 +67,15 @@ app = FastAPI(
             "description": "Base API server",
         }
     ],
-    lifespan=lifespan
+    lifespan=lifespan,
 )
-
 
 
 # Include routers for feature modules
 app.include_router(send_router)
 app.include_router(read_router)
 app.include_router(imap_router)
+
 
 def custom_openapi() -> dict:
     if app.openapi_schema:
@@ -109,7 +105,7 @@ app.openapi = custom_openapi
 
 
 @app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException):
+def http_exception_handler(request: Request, exc: HTTPException):
     if isinstance(exc.detail, dict):
         return JSONResponse(status_code=exc.status_code, content=exc.detail)
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})

--- a/app/models.py
+++ b/app/models.py
@@ -1,22 +1,37 @@
-# flake8: noqa
 # models.py
 from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, EmailStr, Field, HttpUrl, field_validator
 
+
 class SendEmailRequest(BaseModel):
     to_addresses: list[EmailStr] = Field(
-        ..., description="List of recipient email addresses.", min_length=1, json_schema_extra={"example": ["friend@example.com"], "minItems": 1}
+        ...,
+        description="List of recipient email addresses.",
+        min_length=1,
+        json_schema_extra={"example": ["friend@example.com"], "minItems": 1},
     )
     subject: str = Field(
-        ..., description="The subject of the email.", max_length=255, min_length=1, json_schema_extra={"example": "Hello"}
+        ...,
+        description="The subject of the email.",
+        max_length=255,
+        min_length=1,
+        json_schema_extra={"example": "Hello"},
     )
     body: str = Field(
-        ..., description="The body content of the email.", min_length=1, json_schema_extra={"example": "Hi there"}
+        ...,
+        description="The body content of the email.",
+        min_length=1,
+        json_schema_extra={"example": "Hi there"},
     )
     file_url: Optional[list[HttpUrl]] = Field(
-        default=None, description="The URL or comma-separated URLs of the files to be downloaded and attached to the email.", json_schema_extra={"example": ["https://example.com/file.txt"]}
+        default=None,
+        description=(
+            "The URL or comma-separated URLs of the files to be downloaded and "
+            "attached to the email."
+        ),
+        json_schema_extra={"example": ["https://example.com/file.txt"]},
     )
 
     @field_validator("file_url", mode="before")
@@ -34,19 +49,33 @@ class SendEmailRequest(BaseModel):
 
 class EmailSummary(BaseModel):
     uid: str = Field(
-        ..., min_length=1, description="Unique identifier of the email.", json_schema_extra={"example": "1"}
+        ...,
+        min_length=1,
+        description="Unique identifier of the email.",
+        json_schema_extra={"example": "1"},
     )
     subject: str | None = Field(
-        default=None, max_length=255, description="Subject line of the email.", json_schema_extra={"example": "Hello"}
+        default=None,
+        max_length=255,
+        description="Subject line of the email.",
+        json_schema_extra={"example": "Hello"},
     )
     from_: str | None = Field(
-        default=None, alias="from", max_length=255, description="Sender email address.", json_schema_extra={"example": "sender@example.com"}
+        default=None,
+        alias="from",
+        max_length=255,
+        description="Sender email address.",
+        json_schema_extra={"example": "sender@example.com"},
     )
     date: datetime | None = Field(
-        default=None, description="Date the email was sent.", json_schema_extra={"example": "2024-01-01T12:00:00Z"}
+        default=None,
+        description="Date the email was sent.",
+        json_schema_extra={"example": "2024-01-01T12:00:00Z"},
     )
     seen: bool = Field(
-        ..., description="Whether the email has been read.", json_schema_extra={"example": False}
+        ...,
+        description="Whether the email has been read.",
+        json_schema_extra={"example": False},
     )
 
     class Config:
@@ -56,14 +85,22 @@ class EmailSummary(BaseModel):
 
 class MessageResponse(BaseModel):
     message: str = Field(
-        ..., min_length=1, description="Human-readable response message.", json_schema_extra={"example": "Email sent"}
+        ...,
+        min_length=1,
+        description="Human-readable response message.",
+        json_schema_extra={"example": "Email sent"},
     )
 
 
 class ErrorResponse(BaseModel):
     detail: str = Field(
-        ..., min_length=1, description="Error message detail.", json_schema_extra={"example": "Invalid request"}
+        ...,
+        min_length=1,
+        description="Error message detail.",
+        json_schema_extra={"example": "Invalid request"},
     )
     code: str | None = Field(
-        default=None, description="Optional error code.", json_schema_extra={"example": "invalid_request"}
+        default=None,
+        description="Optional error code.",
+        json_schema_extra={"example": "invalid_request"},
     )

--- a/app/routes/read_email.py
+++ b/app/routes/read_email.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from fastapi import APIRouter, Body, HTTPException, Path, Query, Security
 
 from ..dependencies import get_api_key, send_email
@@ -46,7 +45,10 @@ read_router = APIRouter(tags=["Read"])
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },
@@ -97,11 +99,7 @@ async def get_emails(
     description="List available mail folders.",
     operation_id="list_folders",
     responses={
-        200: {
-            "content": {
-                "application/json": {"example": ["INBOX", "Archive"]}
-            }
-        },
+        200: {"content": {"application/json": {"example": ["INBOX", "Archive"]}}},
         400: {
             "model": ErrorResponse,
             "description": "Invalid request",
@@ -116,7 +114,10 @@ async def get_emails(
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },
@@ -164,13 +165,7 @@ async def get_folders() -> list[str]:
     response_model=MessageResponse,
     operation_id="move_email",
     responses={
-        200: {
-            "content": {
-                "application/json": {
-                    "example": {"message": "Email moved"}
-                }
-            }
-        },
+        200: {"content": {"application/json": {"example": {"message": "Email moved"}}}},
         400: {
             "model": ErrorResponse,
             "description": "Invalid request",
@@ -185,7 +180,10 @@ async def get_folders() -> list[str]:
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },
@@ -235,11 +233,7 @@ async def move_email(
     operation_id="forward_email",
     responses={
         200: {
-            "content": {
-                "application/json": {
-                    "example": {"message": "Email forwarded"}
-                }
-            }
+            "content": {"application/json": {"example": {"message": "Email forwarded"}}}
         },
         400: {
             "model": ErrorResponse,
@@ -255,7 +249,10 @@ async def move_email(
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },
@@ -303,14 +300,15 @@ async def forward_email(
             }
         },
     ),
+    folder: str = Query("INBOX", description="Mail folder to read from"),
 ) -> MessageResponse:
     try:
-        original = await imap.fetch_message(uid)
+        original = await imap.fetch_message(uid, folder)
         original_body = imap.extract_body(original)
-        body = (
-            f"{request.body}\n\n{original_body}" if request.body else original_body
+        body = f"{request.body}\n\n{original_body}" if request.body else original_body
+        subject = request.subject or imap.decode_header_value(
+            original.get("Subject", "")
         )
-        subject = request.subject or imap.decode_header_value(original.get("Subject", ""))
         msg_id = original.get("Message-ID")
         headers = {}
         if msg_id:
@@ -335,13 +333,7 @@ async def forward_email(
     response_model=MessageResponse,
     operation_id="reply_email",
     responses={
-        200: {
-            "content": {
-                "application/json": {
-                    "example": {"message": "Email sent"}
-                }
-            }
-        },
+        200: {"content": {"application/json": {"example": {"message": "Email sent"}}}},
         400: {
             "model": ErrorResponse,
             "description": "Invalid request",
@@ -356,7 +348,10 @@ async def forward_email(
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },
@@ -404,9 +399,10 @@ async def reply_email(
             }
         },
     ),
+    folder: str = Query("INBOX", description="Mail folder to read from"),
 ) -> MessageResponse:
     try:
-        original = await imap.fetch_message(uid)
+        original = await imap.fetch_message(uid, folder)
         body = request.body or imap.extract_body(original)
         subj = imap.decode_header_value(original.get("Subject", ""))
         subject = request.subject or f"Re: {subj}"
@@ -435,11 +431,7 @@ async def reply_email(
     operation_id="delete_email",
     responses={
         200: {
-            "content": {
-                "application/json": {
-                    "example": {"message": "Email deleted"}
-                }
-            }
+            "content": {"application/json": {"example": {"message": "Email deleted"}}}
         },
         400: {
             "model": ErrorResponse,
@@ -455,7 +447,10 @@ async def reply_email(
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },
@@ -504,11 +499,7 @@ async def delete_email(
     operation_id="create_draft",
     responses={
         200: {
-            "content": {
-                "application/json": {
-                    "example": {"message": "Draft stored"}
-                }
-            }
+            "content": {"application/json": {"example": {"message": "Draft stored"}}}
         },
         400: {
             "model": ErrorResponse,
@@ -524,7 +515,10 @@ async def delete_email(
             "description": "Missing API key",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Not authenticated", "code": "not_authenticated"}
+                    "example": {
+                        "detail": "Not authenticated",
+                        "code": "not_authenticated",
+                    }
                 }
             },
         },

--- a/app/routes/send_email.py
+++ b/app/routes/send_email.py
@@ -13,14 +13,12 @@ logger = logging.getLogger(__name__)
     dependencies=[Security(get_api_key)],
     summary="Send an email",
     description="Send an email to one or more recipients.",
-    status_code=200,
+    status_code=201,
     response_model=MessageResponse,
     responses={
-        200: {
+        201: {
             "content": {
-                "application/json": {
-                    "example": {"message": "Email sent successfully"}
-                }
+                "application/json": {"example": {"message": "Email sent successfully"}}
             }
         },
         400: {
@@ -90,14 +88,10 @@ async def send_email_endpoint(
 ) -> MessageResponse:
     subject = request.subject
     body = request.body
-    file_urls = (
-        [str(url) for url in request.file_url] if request.file_url else None
-    )
+    file_urls = [str(url) for url in request.file_url] if request.file_url else None
 
     try:
-        await send_email(
-            request.to_addresses, subject, body, file_urls=file_urls
-        )
+        await send_email(request.to_addresses, subject, body, file_urls=file_urls)
         return MessageResponse(message="Email sent successfully")
     except HTTPException as e:
         logger.error("HTTPException: %s", e.detail)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-import asyncio
 import os
 import sys
 from pathlib import Path
@@ -62,36 +60,36 @@ class MockSession:
         return self._response
 
 
-def test_fetch_file_success(tmp_path):
+@pytest.mark.asyncio
+async def test_fetch_file_success(tmp_path):
     session = MockSession(MockResponse(200, [b"data"]))
-    file_path = asyncio.run(
-        dependencies.fetch_file(session, "http://example.com/file.txt", tmp_path)
+    file_path = await dependencies.fetch_file(
+        session, "http://example.com/file.txt", tmp_path
     )
     assert Path(file_path).exists()
 
 
-def test_fetch_file_non_200(tmp_path):
+@pytest.mark.asyncio
+async def test_fetch_file_non_200(tmp_path):
     session = MockSession(MockResponse(404))
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(
-            dependencies.fetch_file(session, "http://example.com/file.txt", tmp_path)
-        )
+        await dependencies.fetch_file(session, "http://example.com/file.txt", tmp_path)
     assert exc.value.status_code == 404
 
 
-def test_fetch_file_disallowed_extension(tmp_path):
+@pytest.mark.asyncio
+async def test_fetch_file_disallowed_extension(tmp_path):
     session = MockSession(MockResponse(200))
     with pytest.raises(HTTPException):
-        asyncio.run(
-            dependencies.fetch_file(session, "http://example.com/file.exe", tmp_path)
-        )
+        await dependencies.fetch_file(session, "http://example.com/file.exe", tmp_path)
 
 
-def test_fetch_file_streams_chunks(tmp_path):
+@pytest.mark.asyncio
+async def test_fetch_file_streams_chunks(tmp_path):
     chunks = [b"a" * 1024, b"b" * 1024, b"c" * 1024]
     session = MockSession(MockResponse(200, chunks))
-    file_path = asyncio.run(
-        dependencies.fetch_file(session, "http://example.com/file.txt", tmp_path)
+    file_path = await dependencies.fetch_file(
+        session, "http://example.com/file.txt", tmp_path
     )
     assert Path(file_path).stat().st_size == 3 * 1024
 
@@ -103,7 +101,8 @@ async def fake_fetch_file(session, url, temp_dir):
     return str(path)
 
 
-def test_send_email_with_attachment(monkeypatch):
+@pytest.mark.asyncio
+async def test_send_email_with_attachment(monkeypatch):
     monkeypatch.setattr(dependencies, "fetch_file", fake_fetch_file)
     sent = {}
 
@@ -112,15 +111,12 @@ def test_send_email_with_attachment(monkeypatch):
 
     monkeypatch.setattr(aiosmtplib, "send", mock_send)
     dependencies.settings.account_reply_to = "reply@example.com"
-    asyncio.run(
-        dependencies.send_email(
-            ["a@b.com"], "Sub", "Body", ["http://f1.txt"]
-        )
-    )
+    await dependencies.send_email(["a@b.com"], "Sub", "Body", ["http://f1.txt"])
     assert "Reply-To" in sent["msg"]
 
 
-def test_send_email_with_multiple_attachments(monkeypatch):
+@pytest.mark.asyncio
+async def test_send_email_with_multiple_attachments(monkeypatch):
     monkeypatch.setattr(dependencies, "fetch_file", fake_fetch_file)
     sent = {}
 
@@ -128,16 +124,15 @@ def test_send_email_with_multiple_attachments(monkeypatch):
         sent["msg"] = msg
 
     monkeypatch.setattr(aiosmtplib, "send", mock_send)
-    asyncio.run(
-        dependencies.send_email(
-            ["a@b.com"], "Sub", "Body", ["http://f1.txt", "http://f2.txt"]
-        )
+    await dependencies.send_email(
+        ["a@b.com"], "Sub", "Body", ["http://f1.txt", "http://f2.txt"]
     )
     # 1 body part + 2 attachments
     assert len(sent["msg"].get_payload()) == 3
 
 
-def test_send_email_total_size_exceeded(monkeypatch):
+@pytest.mark.asyncio
+async def test_send_email_total_size_exceeded(monkeypatch):
     async def fake_fetch(session, url, temp_dir):
         path = Path(temp_dir) / Path(url).name
         async with aiofiles.open(path, "wb") as f:
@@ -148,25 +143,23 @@ def test_send_email_total_size_exceeded(monkeypatch):
     sizes = [15 * 1024 * 1024, 10 * 1024 * 1024]
     monkeypatch.setattr("app.dependencies.os.path.getsize", lambda _: sizes.pop(0))
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(
-            dependencies.send_email(
-                ["a@b.com"], "Sub", "Body", ["http://f1.txt", "http://f2.txt"]
-            )
+        await dependencies.send_email(
+            ["a@b.com"], "Sub", "Body", ["http://f1.txt", "http://f2.txt"]
         )
     assert exc.value.status_code == 413
 
 
-def test_send_email_single_file_oversize(monkeypatch):
+@pytest.mark.asyncio
+async def test_send_email_single_file_oversize(monkeypatch):
     monkeypatch.setattr(dependencies, "fetch_file", fake_fetch_file)
     monkeypatch.setattr("app.dependencies.os.path.getsize", lambda _: 25 * 1024 * 1024)
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(
-            dependencies.send_email(["a@b.com"], "Sub", "Body", ["http://f1.txt"])
-        )
+        await dependencies.send_email(["a@b.com"], "Sub", "Body", ["http://f1.txt"])
     assert exc.value.status_code == 413
 
 
-def test_send_email_missing_reply_to(monkeypatch):
+@pytest.mark.asyncio
+async def test_send_email_missing_reply_to(monkeypatch):
     dependencies.settings.account_reply_to = None
     sent = {}
 
@@ -174,39 +167,41 @@ def test_send_email_missing_reply_to(monkeypatch):
         sent["msg"] = msg
 
     monkeypatch.setattr(aiosmtplib, "send", mock_send)
-    asyncio.run(dependencies.send_email(["a@b.com"], "Sub", "Body"))
+    await dependencies.send_email(["a@b.com"], "Sub", "Body")
     assert "Reply-To" not in sent["msg"]
 
 
-def test_send_email_smtp_exception(monkeypatch):
+@pytest.mark.asyncio
+async def test_send_email_smtp_exception(monkeypatch):
     async def mock_send(*args, **kwargs):
         raise aiosmtplib.errors.SMTPException("fail")
 
     monkeypatch.setattr(aiosmtplib, "send", mock_send)
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(dependencies.send_email(["a@b.com"], "Sub", "Body"))
+        await dependencies.send_email(["a@b.com"], "Sub", "Body")
     assert exc.value.status_code == 500
 
 
 # Existing API key tests retained
 
+
 def test_get_api_key_without_env(monkeypatch):
     monkeypatch.delenv("API_KEY", raising=False)
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
-    assert asyncio.run(dependencies.get_api_key(credentials=creds)) == "token"
-    assert asyncio.run(dependencies.get_api_key(credentials=None)) is None
+    assert dependencies.get_api_key(credentials=creds) == "token"
+    assert dependencies.get_api_key(credentials=None) is None
 
 
 def test_get_api_key_with_env_valid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="secret")
-    assert asyncio.run(dependencies.get_api_key(credentials=creds)) == "secret"
+    assert dependencies.get_api_key(credentials=creds) == "secret"
 
 
 def test_get_api_key_with_env_invalid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong")
     with pytest.raises(HTTPException):
-        asyncio.run(dependencies.get_api_key(credentials=creds))
+        dependencies.get_api_key(credentials=creds)
     with pytest.raises(HTTPException):
-        asyncio.run(dependencies.get_api_key(credentials=None))
+        dependencies.get_api_key(credentials=None)

--- a/tests/test_imap_routes.py
+++ b/tests/test_imap_routes.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import os
 import sys
 from email.message import EmailMessage

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import os
 import sys
 from pathlib import Path

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from datetime import datetime
 import os
 import sys
@@ -15,12 +14,12 @@ os.environ["ACCOUNT_IMAP_PORT"] = "993"
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.models import (
+from app.models import (  # noqa: E402
     EmailSummary,
     ErrorResponse,
     MessageResponse,
     SendEmailRequest,
-)  # noqa: E402
+)
 
 
 def test_send_email_request_invalid_email():
@@ -54,7 +53,9 @@ def test_send_email_request_invalid_attachment_urls():
 
 def test_email_summary_alias_and_datetime():
     dt = datetime(2024, 1, 1, 12, 0, 0)
-    summary = EmailSummary(uid="1", subject="S", **{"from": "a@b.com"}, date=dt, seen=True)
+    summary = EmailSummary(
+        uid="1", subject="S", **{"from": "a@b.com"}, date=dt, seen=True
+    )
     data = summary.model_dump(by_alias=True)
     assert data["from"] == "a@b.com"
     json_data = summary.model_dump_json(by_alias=True)

--- a/tests/test_read_email.py
+++ b/tests/test_read_email.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import os
 import sys
 from fastapi.testclient import TestClient
@@ -13,11 +12,10 @@ os.environ["ACCOUNT_IMAP_PORT"] = "993"
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.main import app  # noqa: E402
-from app.routes import imap
-from app.models import EmailSummary
-from app import dependencies
-from datetime import datetime
-from app.routes import read_email
+from app.routes import imap  # noqa: E402
+from app.models import EmailSummary  # noqa: E402
+from app import dependencies  # noqa: E402
+from datetime import datetime  # noqa: E402
 
 dependencies.settings = dependencies.Config()
 client = TestClient(app)
@@ -34,7 +32,15 @@ def test_get_folders(monkeypatch):
 
 
 def test_get_emails(monkeypatch):
-    sample = [EmailSummary(uid="1", subject="Test", from_="a@example.com", date=datetime.utcnow(), seen=False)]
+    sample = [
+        EmailSummary(
+            uid="1",
+            subject="Test",
+            from_="a@example.com",
+            date=datetime.utcnow(),
+            seen=False,
+        )
+    ]
 
     async def mock_fetch_messages(folder: str, limit: int, unread_only: bool):
         return sample
@@ -89,16 +95,25 @@ def test_forward_email(monkeypatch):
     class DummyMessage:
         def __init__(self):
             self.headers = {"Message-ID": "<1@example.com>", "Subject": "Original"}
+
         def get(self, key, default=""):
             return self.headers.get(key, default)
 
-    async def mock_fetch(uid):
+    async def mock_fetch(uid, folder="INBOX"):
         return DummyMessage()
 
     sent = {}
 
     async def mock_send(to, subject, body, file_urls, headers):
-        sent.update({"to": to, "subject": subject, "body": body, "headers": headers, "files": file_urls})
+        sent.update(
+            {
+                "to": to,
+                "subject": subject,
+                "body": body,
+                "headers": headers,
+                "files": file_urls,
+            }
+        )
 
     monkeypatch.setattr(imap, "fetch_message", mock_fetch)
     monkeypatch.setattr(imap, "extract_body", lambda msg: "body")
@@ -106,7 +121,12 @@ def test_forward_email(monkeypatch):
     monkeypatch.setattr("app.routes.read_email.send_email", mock_send)
     response = client.post(
         "/emails/1/forward",
-        json={"to_addresses": ["a@b.com"], "subject": "S", "body": "B", "file_url": None},
+        json={
+            "to_addresses": ["a@b.com"],
+            "subject": "S",
+            "body": "B",
+            "file_url": None,
+        },
     )
     assert response.status_code == 200
     assert sent["subject"] == "S"
@@ -120,16 +140,25 @@ def test_reply_email(monkeypatch):
     class DummyMessage:
         def __init__(self):
             self.headers = {"Message-ID": "<2@example.com>", "Subject": "Orig"}
+
         def get(self, key, default=""):
             return self.headers.get(key, default)
 
-    async def mock_fetch(uid):
+    async def mock_fetch(uid, folder="INBOX"):
         return DummyMessage()
 
     sent = {}
 
     async def mock_send(to, subject, body, file_urls, headers):
-        sent.update({"to": to, "subject": subject, "body": body, "headers": headers, "files": file_urls})
+        sent.update(
+            {
+                "to": to,
+                "subject": subject,
+                "body": body,
+                "headers": headers,
+                "files": file_urls,
+            }
+        )
 
     monkeypatch.setattr(imap, "fetch_message", mock_fetch)
     monkeypatch.setattr(imap, "extract_body", lambda msg: "orig body")
@@ -137,7 +166,12 @@ def test_reply_email(monkeypatch):
     monkeypatch.setattr("app.routes.read_email.send_email", mock_send)
     response = client.post(
         "/emails/2/reply",
-        json={"to_addresses": ["a@b.com"], "subject": "S", "body": "B", "file_url": None},
+        json={
+            "to_addresses": ["a@b.com"],
+            "subject": "S",
+            "body": "B",
+            "file_url": None,
+        },
     )
     assert response.status_code == 200
     assert sent["subject"] == "S"
@@ -155,15 +189,22 @@ def test_create_draft(monkeypatch):
     monkeypatch.setattr(imap, "append_message", mock_append)
     response = client.post(
         "/drafts",
-        json={"to_addresses": ["x@y.com"], "subject": "S", "body": "B", "file_url": None},
+        json={
+            "to_addresses": ["x@y.com"],
+            "subject": "S",
+            "body": "B",
+            "file_url": None,
+        },
     )
     assert response.status_code == 200
     assert called["folder"] == "Drafts"
     assert response.json() == {"message": "Draft stored"}
 
+
 def test_get_folders_error(monkeypatch):
     async def fail():
         raise RuntimeError("boom")
+
     monkeypatch.setattr(imap, "list_mailboxes", fail)
     resp = client.get("/folders")
     assert resp.status_code == 500
@@ -172,6 +213,7 @@ def test_get_folders_error(monkeypatch):
 def test_get_emails_error(monkeypatch):
     async def fail(folder, limit, unread_only):
         raise RuntimeError("boom")
+
     monkeypatch.setattr(imap, "fetch_messages", fail)
     resp = client.get("/emails")
     assert resp.status_code == 500
@@ -180,6 +222,7 @@ def test_get_emails_error(monkeypatch):
 def test_move_email_error(monkeypatch):
     async def fail(uid, folder, source_folder):
         raise RuntimeError("boom")
+
     monkeypatch.setattr(imap, "move_message", fail)
     resp = client.post("/emails/1/move?folder=Archive")
     assert resp.status_code == 500
@@ -189,6 +232,11 @@ def test_create_draft_missing_settings(monkeypatch):
     monkeypatch.setattr(dependencies, "settings", None)
     resp = client.post(
         "/drafts",
-        json={"to_addresses": ["x@y.com"], "subject": "S", "body": "B", "file_url": None},
+        json={
+            "to_addresses": ["x@y.com"],
+            "subject": "S",
+            "body": "B",
+            "file_url": None,
+        },
     )
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- make API key and HTTP error helpers synchronous
- emit structured logs and return 201 for send email endpoint
- add folder query for forward/reply and modernize tests & linting

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2beb294ac832abaec9a22b2c34a8d