### PR TITLE
Add pytest configuration and test documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Standardized `ErrorResponse` model with example payloads and documented 401/403 responses.
 - Example request bodies and success responses for email routes and models.
 - OpenAPI metadata now declares version 3.1.0 and derives the server URL from `BASE_URL` and `ROOT_PATH` environment variables.
- - Streaming attachment downloads to disk to limit memory usage.
+- Streaming attachment downloads to disk to limit memory usage.
+- Added `requirements-dev.txt` with `pytest` and `pytest-asyncio`, and documented test execution steps.
 
 ### Changed
 - Routes and IMAP client now reference settings dynamically via `dependencies.settings`.

--- a/README.md
+++ b/README.md
@@ -196,11 +196,20 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
    | `DELETE /emails/{uid}` | Delete a message from a folder (defaults to `INBOX`). |
    | `POST /drafts` | Store a draft message in the "Drafts" folder. |
 
+### 🧪 Testing
+
+Run the test suite locally with:
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
 ---
 
 ## 🛠 Project Changelog
 
--  `► `
+-  `► Added pytest configuration and testing instructions`
 -  `► `
 -  `► `
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    asyncio: marks tests requiring an event loop
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add requirements-dev.txt with pytest and pytest-asyncio
- configure pytest with asyncio marker and auto mode
- document test installation and execution in README

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c41232d0832a979158cdb568cb39