### PR TITLE
Use X-API-Key header for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Email summary dates stored as `datetime` and serialized in ISO format.
 - Send/Read tags added to the FastAPI application.
 - Consistent `MessageResponse` model used across message endpoints and documented error responses.
-- Named API key bearer security scheme exposed in the OpenAPI schema.
+- Named `X-API-Key` header security scheme exposed in the OpenAPI schema.
 - Tests for API key validation and email sending error handling.
 - Extensive tests for dependencies, IMAP client, routes, models, and startup logic.
 - `account_reply_to` configuration option for customizing the Reply-To header.
@@ -49,7 +49,7 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Removed blanket `flake8` ignores in favor of targeted suppressions.
 - `SendEmailRequest.file_url` renamed to `file_urls`.
 - Attachment filenames are sanitized and path traversal is blocked.
-- `get_api_key` now requires a Bearer token and rejects missing credentials.
+- `get_api_key` now requires an `X-API-Key` header and rejects missing credentials.
 - Invalid SMTP or IMAP port values raise a descriptive `RuntimeError`.
 - Temporary attachment directories are removed in a background thread to avoid blocking.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
 | 🔌 | **Integrations**  | Integrates key libraries such as FastAPI, Uvicorn, Pydantic for data validation, aiosmtplib for email, and aiohttp for HTTP requests. Environment variables managed using `python-dotenv`. Docker integration for containerization. |
 | 🧩 | **Modularity**    | The codebase is highly modular with separate files for dependencies, models, and routes, facilitating reusability and easy maintenance. Logical separation of concerns across the application layers. |
 | ⚡️  | **Performance**   | High efficiency and performance due to asynchronous programming with FastAPI and Uvicorn. Docker ensures optimized resource usage by providing isolated environments. |
-| 🛡️ | **Security**      | Uses environment variables for sensitive configurations, API key validation for access control, and enforces file size and type constraints. Prioritizes secure email transmission and data protection. |
+| 🛡️ | **Security**      | Uses environment variables for sensitive configurations, API key validation via the `X-API-Key` header for access control, and enforces file size and type constraints. Prioritizes secure email transmission and data protection. |
 | 📦 | **Dependencies**  | Key dependencies include `aiohttp`, `pydantic`, `uvicorn`, `fastapi`, `aiosmtplib`, `python-dotenv`, and `aiofiles`. Managed using `requirements.txt` for easy installation and updates. |
 | 🚀 | **Scalability**   | Designed for scalability with Docker and FastAPI. Can handle increased load efficiently due to asynchronous request handling and container orchestration capabilities provided by Docker Compose. |
 ```
@@ -156,6 +156,12 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
     The service validates the SMTP settings on startup. Ensure `ACCOUNT_EMAIL`,
     `ACCOUNT_PASSWORD`, `ACCOUNT_SMTP_SERVER`, and `ACCOUNT_SMTP_PORT` are set
     or the application will raise a runtime error at launch.
+
+   If `API_KEY` is set, include it in requests using the `X-API-Key` header:
+
+   ```bash
+   curl -H "X-API-Key: $API_KEY" https://api.example.com/email/...
+   ```
 
 3. **Run the Docker Compose**:  
    Use the following command to start the service:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,5 +20,5 @@ def env(monkeypatch):
 async def client(env):
     async with LifespanManager(app):
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            ac.headers["Authorization"] = "Bearer token"
+            ac.headers["X-API-Key"] = "token"
             yield ac

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -4,7 +4,6 @@ import aiofiles
 import aiosmtplib
 import pytest
 from fastapi import HTTPException
-from fastapi.security import HTTPAuthorizationCredentials
 
 from app import dependencies
 
@@ -176,24 +175,21 @@ async def test_send_email_smtp_exception(monkeypatch):
 @pytest.mark.asyncio
 async def test_get_api_key_without_env(monkeypatch):
     monkeypatch.delenv("API_KEY", raising=False)
-    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
-    assert dependencies.get_api_key(credentials=creds) == "token"
+    assert dependencies.get_api_key(api_key="token") == "token"
     with pytest.raises(HTTPException):
-        dependencies.get_api_key(credentials=None)
+        dependencies.get_api_key(api_key=None)
 
 
 @pytest.mark.asyncio
 async def test_get_api_key_with_env_valid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
-    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="secret")
-    assert dependencies.get_api_key(credentials=creds) == "secret"
+    assert dependencies.get_api_key(api_key="secret") == "secret"
 
 
 @pytest.mark.asyncio
 async def test_get_api_key_with_env_invalid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
-    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong")
     with pytest.raises(HTTPException):
-        dependencies.get_api_key(credentials=creds)
+        dependencies.get_api_key(api_key="wrong")
     with pytest.raises(HTTPException):
-        dependencies.get_api_key(credentials=None)
+        dependencies.get_api_key(api_key=None)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ async def test_startup_with_signature(tmp_path):
     sig_file.write_text("Hello")
     async with LifespanManager(app):
         async with AsyncClient(app=app, base_url="http://test") as client:
-            client.headers["Authorization"] = "Bearer token"
+            client.headers["X-API-Key"] = "token"
             await client.get("/openapi.json")
     assert dependencies.signature_text == "Hello"
     if original is not None:
@@ -34,7 +34,7 @@ async def test_startup_without_signature(tmp_path):
     dependencies.signature_text = ""
     async with LifespanManager(app):
         async with AsyncClient(app=app, base_url="http://test") as client:
-            client.headers["Authorization"] = "Bearer token"
+            client.headers["X-API-Key"] = "token"
             await client.get("/openapi.json")
     assert dependencies.signature_text == ""
     if temp.exists():
@@ -53,7 +53,7 @@ async def test_startup_does_not_configure_logging(monkeypatch):
     monkeypatch.setattr(logging, "basicConfig", fake_basicConfig)
     async with LifespanManager(app):
         async with AsyncClient(app=app, base_url="http://test") as client:
-            client.headers["Authorization"] = "Bearer token"
+            client.headers["X-API-Key"] = "token"
             await client.get("/openapi.json")
     assert not called
     assert logging.getLogger().level == original_level


### PR DESCRIPTION
## Summary
- replace HTTPBearer with APIKeyHeader dependency
- document `X-API-Key` header in README and CHANGELOG
- adjust tests and OpenAPI to use the new header

## Testing
- `flake8 app/dependencies.py app/main.py tests/conftest.py tests/test_dependencies.py tests/test_main.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2cff29dec832a8ef1dad9603864b5