### PR TITLE
Fix Docker startup module path and document container changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,8 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Routes and IMAP client now reference settings dynamically via `dependencies.settings`.
 - Explicit operation IDs defined for read email endpoints.
 - `send_email` accepts a list of attachment URLs via `file_urls` instead of a comma-separated string.
+
+### Fixed
+- Docker images now load the ASGI application via `uvicorn app.main:app` so that package-relative imports resolve in containers.
+- FastAPI helpers (`get_openapi`, `HTTPException`, `Request`, `JSONResponse`) are imported in `app/main.py` to avoid `NameError`
+  during startup.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 COPY --from=builder /app/venv /app/venv
 
 # Copy the rest of the application
-COPY ./app /app
+COPY ./app /app/app
 
 EXPOSE 8888
 
@@ -27,4 +27,4 @@ ENV WORKERS=2
 ENV UVICORN_CONCURRENCY=32
 ENV PATH="/app/venv/bin:$PATH"
 
-CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port 8888 --workers $WORKERS --limit-concurrency $UVICORN_CONCURRENCY --timeout-keep-alive 32"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port 8888 --workers $WORKERS --limit-concurrency $UVICORN_CONCURRENCY --timeout-keep-alive 32"]

--- a/README.md
+++ b/README.md
@@ -166,14 +166,20 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
     `ACCOUNT_PASSWORD`, `ACCOUNT_SMTP_SERVER`, and `ACCOUNT_SMTP_PORT` are set
     or the application will raise a runtime error at launch.
 
-3. **Run the Docker Compose**:  
+3. **Run the Docker Compose**:
    Use the following command to start the service:
 
    ```bash
    docker-compose up
    ```
 
-4. **(Optional) Run in Detached Mode**:  
+   The provided Dockerfile now copies the application into an `app/` package and runs
+   `uvicorn app.main:app` so that the FastAPI module is loaded through the package.
+   When building your own images or launching Uvicorn locally, use the same module
+   path (or ensure the source lives inside an `app/` package) to keep the relative
+   imports working.
+
+4. **(Optional) Run in Detached Mode**:
    To run the containers in the background, use:
 
    ```bash
@@ -209,7 +215,8 @@ The v-gpt-email-api is a sophisticated email management system designed to enhan
 
 ## 🛠 Project Changelog
 
--  `► `
+-  `► `2025-09-19: Container images run `uvicorn app.main:app` and document the
+   package import requirement for consistent deployment.
 -  `► `
 -  `► `
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,10 @@
 # main,py
 import os
+
 import aiofiles
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
 
 from . import dependencies
 from .routes.send_email import send_router


### PR DESCRIPTION
## Summary
- import the FastAPI helpers used by the OpenAPI override and HTTP exception handler so the app boots cleanly
- run Uvicorn against `app.main:app` in the Docker image and copy the sources into the `app/` package to preserve relative imports
- document the deployment fix in the README and changelog

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd98d5528832aa1c5d70ad760d417